### PR TITLE
Add heroku build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,6 @@
       "commit-msg": "secret-squirrel-commitmsg",
       "pre-commit": "secret-squirrel"
     }
-  }
+  },
+  "heroku-run-build-script": true
 }


### PR DESCRIPTION
Add `heroku-run-build-script: true` to all repos as part of new security requirements. If you have `heroku-postbuild` command then that will need to go on to your `build` script.