### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Financial-Times/email-platform-engineers


### PR DESCRIPTION
This adds a CODEOWNERS file which in turn will allow for automatic tagging of the Email Platform Engineers team to review and to prevent merges without a review.